### PR TITLE
Initial changes to make the repository follow cig template.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,11 @@
+GEM NOTEBOOKS being developed by a large, collaborative, and inclusive
+community. It is currently maintained by the following people:
+  
+  Jarret Baker-Dunn
+  Lorraine Hwang
+  John Naliboff
+  Arushi Saxena
+
+A complete list of the authors that have contributed and or reviewed this
+repository can be found at
+   https://geodynamics.org/groups/education

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to Geodynamic Educational Modules (GEM) Notebooks
+
+GEM-notebooks is a community project that lives by the participation of its
+members — i.e., including you! It is our goal to build an inclusive
+and participatory community so we are happy that you are interested in
+participating!
+
+## Bug reports
+
+It is a great help to the community if you report any bugs that you
+may find. We keep track of all open issues related to this project
+[here](https://github.com/geodynamics-hubzero/gem-notebooks/issues).
+
+Please follow these simple instructions before opening a new bug report:
+
+- Do a search in the [list of open and closed issues](https://github.com/geodynamics-hubzero/gem-notebooks/issues)
+  for a duplicate of your problem.
+- If you did not find an answer, open a new
+  [issue](https://github.com/geodynamics-hubzero/gem-notebooks/issues/new) and explain your
+  problem in as much detail as possible.
+- Attach as much as possible of the following information to your issue:
+  - the module and the corresponding notebook in which you encountered the issue.
+  - missing/incorrect information from the module/notebook.
+
+## Making GEM-notebooks better
+
+GEM-notebooks is a community project, aimed at creating educational modules in geodynamics 
+using open-source software. We encourage all contributions that can help make these 
+module more accessible and clearer to our users. Some examples include any contributions
+of an problem/example to better convey a geodynamic process or a physical process that is 
+not yet covered in these modules.
+
+### Opening pull requests
+
+To make a change to this repository you should:
+
+- Create a
+[fork](https://guides.github.com/activities/forking/#fork) (through GitHub) of
+the code base.
+- Create a separate
+[branch](https://guides.github.com/introduction/flow/) (sometimes called a
+feature branch) on which you do your modifications.
+- You can propose that your branch be merged into the ASPECT
+code by opening a [pull request](https://guides.github.com/introduction/flow/).
+This will give others a chance to review your code.
+
+## Acknowledgment of contributions
+
+We are grateful for every contribution and we will acknowledge your contribution on
+our [webpage](https://geodynamics.org/groups/education) and in our repository under the
+[AUTHORS](https://github.com/geodynamics-hubzero/gem-notebooks/blob/main/AUTHORS) list.
+
+## License
+
+GEM-notebooks is published under the
+[GPL v2 or newer](https://github.com/geodynamics/gem-notebooks/blob/main/LICENSE);
+while you will retain copyright on your contributions, all changes to the code
+must be provided under this common license.


### PR DESCRIPTION
Since our goal is to eventually make this repository part of CIG repositories (or [geodynamcis.org)](https://github.com/geodynamics/), we want to make sure it follows the software template [here](https://github.com/geodynamics/software_template/tree/main).  This PR adds some initial changes towards following this template. 
However, there are some other changes I want to recommend and have not pushed here: 

- [ ] remove `doc/` `rappture/` `middleware/` : right now, it is unclear to me what the purpose of these folders is
- [ ] rename `bin/` to `src/`
- [ ] move the data from the notebooks in the top `data` directory (maybe a controversial opinion).

Let me know what you all think!